### PR TITLE
update for next release

### DIFF
--- a/App/tools/driver.makefile
+++ b/App/tools/driver.makefile
@@ -832,6 +832,10 @@ vpath menu%.dbd ${DBD_PATH}
 
 # Find header files to install.
 vpath %.h $(addprefix ../,$(sort $(dir $(filter-out /%,${HDRS}) ${SRCS}))) $(sort $(dir $(filter /%,${HDRS})))
+vpath %.hpp $(addprefix ../,$(sort $(dir $(filter-out /%,${HDRS}) ${SRCS}))) $(sort $(dir $(filter /%,${HDRS})))
+vpath %.hh $(addprefix ../,$(sort $(dir $(filter-out /%,${HDRS}) ${SRCS}))) $(sort $(dir $(filter /%,${HDRS})))
+vpath %.hxx $(addprefix ../,$(sort $(dir $(filter-out /%,${HDRS}) ${SRCS}))) $(sort $(dir $(filter /%,${HDRS})))
+
 
 PRODUCTS = ${MODULELIB} ${MODULEDBD} ${DEPFILE}
 MODULEINFOS:
@@ -1102,7 +1106,8 @@ endif # EPICSVERSION defined
 ## Tuesday, January 30 14:03:35 CET 2018  : Default snc path (SNC) was changed in order to use E3_SITELIBS_PATH,
 ##                                          at the same time, we also add E3_SITEMODS_PATH, E3_SITEAPPS_PATH also.
 ##                                          They should be configured in E3/CONFIG_EXPORT and E3/CONFIG_E3_MAKEFILE.
-##                                          We also introduce E3_SEQUENCER_NAME also. 
+##                                          We also introduce E3_SEQUENCER_NAME also.
+##
 ## Wednesday, January 31 15:18:33 CET 2018: Add Debug messages in SNC  
 ##
 ## Saturday, February 10 22:42:44 CET 2018: E3_SEQUENCER_VERSION was introduced. If not set, fall back to
@@ -1110,5 +1115,9 @@ endif # EPICSVERSION defined
 ##                                          in the original driver.makefile way.
 ##                                          Default E3_SEQUENCER_NAME as sequencer, if it is not defined in
 ##                                          CONFIG_MODULE in each module
+##
 ## Tuesday, May  1 20:27:31 CEST 2018     : Generate a dependency file with module_name x.x.x instead of x.x
-##                                          add the exclusion for include for require.dep 
+##                                          add the exclusion for include for require.dep
+##
+## Sunday, May  6 22:10:24 CEST 2018      : add %.{hh,hpp,hxx} headers into vpath in order to install them properly
+## 

--- a/App/tools/driver.makefile
+++ b/App/tools/driver.makefile
@@ -1077,7 +1077,7 @@ ${DEPFILE}: ${LIBOBJS} $(USERMAKEFILE)
 	$(RM) $@
 	@echo "# Generated file. Do not edit." > $@
 # Check dependencies on other module headers.
-	cat *.d 2>/dev/null | sed 's/ /\n/g' | sed -n 's%${EPICS_MODULES}/*\([^/]*\)/\([0-9]*\.[0-9]*\)\.[0-9]*/.*%\1 \2%p;s%$(EPICS_MODULES)/*\([^/]*\)/\([^/]*\)/.*%\1 \2%p'| sort -u >> $@
+	cat *.d 2>/dev/null | sed 's/ /\n/g' | sed -n 's%${EPICS_MODULES}/*\([^/]*\)/\([0-9]*\.[0-9]*\.[0-9]*\)/.*%\1 \2%p;s%$(EPICS_MODULES)/*\([^/]*\)/\([^/]*\)/.*%\1 \2%p'| grep -v "include" | sort -u >> $@
 ifneq ($(strip ${REQ}),)
 # Manully added dependencies: ${REQ}
 	@$(foreach m,${REQ},echo "$m $(or ${$m_VERSION},$(and $(wildcard ${EPICS_MODULES}/$m),$(error REQUIRED module $m has no numbered version. Set $m_VERSION)),$(warning REQUIRED module $m not found for ${T_A}.))" >> $@;)
@@ -1110,4 +1110,5 @@ endif # EPICSVERSION defined
 ##                                          in the original driver.makefile way.
 ##                                          Default E3_SEQUENCER_NAME as sequencer, if it is not defined in
 ##                                          CONFIG_MODULE in each module
-##
+## Tuesday, May  1 20:27:31 CEST 2018     : Generate a dependency file with module_name x.x.x instead of x.x
+##                                          add the exclusion for include for require.dep 

--- a/require.c
+++ b/require.c
@@ -1210,8 +1210,15 @@ static int handleDependencies(const char* module, char* depfilename)
             while (*end && !isspace((unsigned char)*end)) end++;
 
             /* add + to numerial versions if not yet there */
+	    /*
+	      ESS would like to use the MATCH version only, not HIGHER. 
+	      In order to touch the PSI code mininaly, disable add + from VERSION from Dep file.
+	      At the same time, ESS use the X.X.X instead of X.X.
+	      Wednesday, May  2 00:12:18 CEST 2018, jhlee
+	    */
+	    /*
             if (*(end-1) != '+' && strspn(rversion, "0123456789.") == (size_t)(end-rversion)) *end++ = '+';
-
+	    */
             /* terminate version */
             *end = 0;
         }


### PR DESCRIPTION
- Use x.x.x version number in *.dep file instead of x.x
- Disable a logic to add + with the reading value from *.dep file
- Add different suffix headers in driver.Makefile in order to install them correctly. 